### PR TITLE
Django debug tool bar

### DIFF
--- a/data_explorer/settings.py
+++ b/data_explorer/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 import os
 import environ
 import dj_database_url
+import socket
 
 env = environ.Env()
 
@@ -32,6 +33,10 @@ DEBUG = True
 ALLOWED_HOSTS = env('ALLOWED_HOSTS', default='localhost').split(',')
 
 
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_COLLAPSED': True,
+}
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -43,10 +48,12 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django_extensions',
     'explorer',
+    'debug_toolbar',
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -168,3 +175,12 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 EXPLORER_CONNECTIONS = {'default db': 'datasets'}
 EXPLORER_DEFAULT_CONNECTION = 'datasets'
 
+# Internal IPs required by the django debug tool bar
+INTERNAL_IPS = [
+    '127.0.0.1',
+]
+
+# If using docker and you would like to not use the tool bar
+# comment out adding the ip to the internal ips list
+ip = socket.gethostbyname(socket.gethostname())
+INTERNAL_IPS += [ip[:-1] + "1"]

--- a/data_explorer/urls.py
+++ b/data_explorer/urls.py
@@ -14,9 +14,17 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from django.conf import settings
 from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('explorer/', include('explorer.urls')),
 ]
+
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        path('__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dj-database-url==0.5.0
+django-debug-toolbar==2.2
 django-environ==0.4.5
 django-extensions==2.2.9
 django==3.0.5


### PR DESCRIPTION
Note unfortunately the tool bar shows up twice once on the main page and another time in the frame showing the schemas

Visiting http://localhost:8000/explorer/schema/datasets directly should allow the result to seen easily for the schemas view.
