### PR TITLE
Enable/hide table browser

### DIFF
--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load sass_tags %}
+{% load useful %}
 {% load render_bundle from webpack_loader %}
 
 <!doctype html>
@@ -91,9 +92,13 @@
                         <li class="govuk-header__navigation-item{% if request.get_full_path == logs_url %} govuk-header__navigation-item--active{% endif %}">
                             <a class="govuk-header__link" href="{{ logs_url }}">Logs</a>
                         </li>
-                        <li class="govuk-header__navigation-item{% if request.get_full_path == table_browser_url %} govuk-header__navigation-item--active{% endif %}">
-                            <a class="govuk-header__link" href="{{ table_browser_url }}">Table browser</a>
-                        </li>
+                        {% is_table_browser_enabled as table_browser %}
+                        {% if table_browser %}
+                            <li class="govuk-header__navigation-item{% if request.get_full_path == table_browser_url %} govuk-header__navigation-item--active{% endif %}">
+                                <a class="govuk-header__link" href="{{ table_browser_url }}">Table browser</a>
+                            </li>
+                        {% endif %}
+                        {% block additional_nav %}{% endblock %}
                     </ul>
                 </nav>
             </div>

--- a/core/templatetags/useful.py
+++ b/core/templatetags/useful.py
@@ -1,0 +1,10 @@
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+
+@register.simple_tag
+def is_table_browser_enabled():
+    return settings.ENABLE_TABLE_BROWSER
+

--- a/data_explorer/settings.py
+++ b/data_explorer/settings.py
@@ -283,3 +283,5 @@ def check_permissions(user):
 
 EXPLORER_PERMISSION_VIEW = check_permissions
 EXPLORER_PERMISSION_CHANGE = check_permissions
+
+ENABLE_TABLE_BROWSER = env.bool('ENABLE_TABLE_BROWSER', default=False)


### PR DESCRIPTION
A setting has been added to hide the table browser link so on initial release the link can be hidden from the menu.

**Before**
<img width="637" alt="Screenshot 2020-05-11 at 11 28 49" src="https://user-images.githubusercontent.com/8222658/81551981-9a2aa280-937a-11ea-9168-224acadc3c59.png">


**After**
<img width="605" alt="Screenshot 2020-05-11 at 11 27 29" src="https://user-images.githubusercontent.com/8222658/81551870-749d9900-937a-11ea-82d6-a09a21d2a2ef.png">


