### PR TITLE
Fix active link

### DIFF
--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -66,36 +66,32 @@
             document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled')
         </script>
         <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-        {% url 'explorer_index' as index_url %}
-        {% url 'query_create' as new_query_url %}
-        {% url 'explorer_playground' as playground_url %}
-        {% url 'explorer_logs' as logs_url %}
-        {% url 'connection_browser_list' as table_browser_url %}
+        {% get_active_menu as active_menu %}
 
         <header class="govuk-header " role="banner" data-module="header">
             <div class="govuk-header__container govuk-width-container">
                 <div class="govuk-header__logotype">
-                    <a href="" class="govuk-header__link govuk-header__link--service-name" target="_blank">Data Explorer</a>
+                    <a href="" class="govuk-header__link govuk-header__link--service-name">Data Explorer</a>
                 </div>
                 <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
                 <nav>
                     <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
-                        <li class="govuk-header__navigation-item{% if request.get_full_path == index_url %} govuk-header__navigation-item--active{% endif %}">
-                            <a class="govuk-header__link" href="{{ index_url }}">Home</a>
+                        <li class="govuk-header__navigation-item{% if active_menu == 'home' %} govuk-header__navigation-item--active{% endif %}">
+                            <a class="govuk-header__link" href="{% url 'explorer_index' %}">Home</a>
                         </li>
-                        <li class="govuk-header__navigation-item{% if request.get_full_path == new_query_url %} govuk-header__navigation-item--active{% endif %}">
-                            <a class="govuk-header__link" href="{{ new_query_url }}">New Query</a>
+                        <li class="govuk-header__navigation-item{% if active_menu == 'new_query' %} govuk-header__navigation-item--active{% endif %}">
+                            <a class="govuk-header__link" href="{% url 'query_create' %}">New Query</a>
                         </li>
-                        <li class="govuk-header__navigation-item{% if request.get_full_path == playground_url %} govuk-header__navigation-item--active{% endif %}">
-                            <a class="govuk-header__link" href="{{ playground_url }}">Playground</a>
+                        <li class="govuk-header__navigation-item{% if active_menu == 'playground' %} govuk-header__navigation-item--active{% endif %}">
+                            <a class="govuk-header__link" href="{% url 'explorer_playground' %}">Playground</a>
                         </li>
-                        <li class="govuk-header__navigation-item{% if request.get_full_path == logs_url %} govuk-header__navigation-item--active{% endif %}">
-                            <a class="govuk-header__link" href="{{ logs_url }}">Logs</a>
+                        <li class="govuk-header__navigation-item{% if active_menu == 'logs' %} govuk-header__navigation-item--active{% endif %}">
+                            <a class="govuk-header__link" href="{% url 'explorer_logs' %}">Logs</a>
                         </li>
                         {% is_table_browser_enabled as table_browser %}
                         {% if table_browser %}
-                            <li class="govuk-header__navigation-item{% if request.get_full_path == table_browser_url %} govuk-header__navigation-item--active{% endif %}">
-                                <a class="govuk-header__link" href="{{ table_browser_url }}">Table browser</a>
+                            <li class="govuk-header__navigation-item{% if active_menu == 'table_browser' %} govuk-header__navigation-item--active{% endif %}">
+                                <a class="govuk-header__link" href="{% url 'connection_browser_list' %}">Table browser</a>
                             </li>
                         {% endif %}
                         {% block additional_nav %}{% endblock %}

--- a/core/templatetags/useful.py
+++ b/core/templatetags/useful.py
@@ -3,8 +3,28 @@ from django.conf import settings
 
 register = template.Library()
 
+HOME_MENU_ITEM = 'home'
+LOGS_MENU_ITEM = 'logs'
+NEW_MENU_ITEM = 'new_query'
+PLAY_MENU_ITEM = 'play'
+TABLE_BROWSER_MENU_ITEM = 'table_browser'
+
 
 @register.simple_tag
 def is_table_browser_enabled():
     return settings.ENABLE_TABLE_BROWSER
 
+
+@register.simple_tag(takes_context=True)
+def get_active_menu(context):
+    view_name = context['request'].resolver_match.url_name
+    if view_name in ['explorer_index', 'query_detail']:
+        return HOME_MENU_ITEM
+    if view_name == 'explorer_logs':
+        return LOGS_MENU_ITEM
+    if view_name == 'explorer_play':
+        return PLAY_MENU_ITEM
+    if view_name == 'query_create':
+        return NEW_MENU_ITEM
+    if view_name in ['connection_browser_list', 'table_browser_list', 'table_browser_detail']:
+        return TABLE_BROWSER_MENU_ITEM


### PR DESCRIPTION
This makes the setting of which link is active in the main menu more robust and fixes an issue with paginated views

**Problem**
https://data-explorer-dev.london.cloudapps.digital/logs/?page=2
- Logs link not highlighted

<img width="804" alt="Screenshot 2020-05-11 at 16 09 13" src="https://user-images.githubusercontent.com/8222658/81577776-cd345c80-93a1-11ea-92ad-36f097e30dc7.png">

**After fix**
<img width="599" alt="Screenshot 2020-05-11 at 16 10 32" src="https://user-images.githubusercontent.com/8222658/81577887-f5bc5680-93a1-11ea-89b6-2d9b3b661130.png">

