### PR TITLE
add scrolling for wide tables

### DIFF
--- a/core/templates/explorer/preview_pane.html
+++ b/core/templates/explorer/preview_pane.html
@@ -2,45 +2,46 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-width-container">
-	<p class="govuk-heading-m govuk-!-margin-bottom-2">
-	    Preview
-	</p>
-	<p class="govuk-body">
-	    Execution time: {{ duration|floatformat:2 }} ms
-	</p>
-	<p class="govuk-body">
-	    {% if rows > total_rows %}
-	    Showing {{ total_rows }} from a total of {{ total_rows }}
-	    {% else %}
-	    Showing {{ rows }} rows from a total of {{ total_rows }}
-	    {% endif %}
-	</p>
+		<p class="govuk-heading-m govuk-!-margin-bottom-2">
+			Preview
+		</p>
+		<p class="govuk-body">
+			Execution time: {{ duration|floatformat:2 }} ms
+		</p>
+		<p class="govuk-body">
+			{% if rows > total_rows %}
+			Showing {{ total_rows }} from a total of {{ total_rows }}
+			{% else %}
+			Showing {{ rows }} rows from a total of {{ total_rows }}
+			{% endif %}
+		</p>
 
-	<table class="govuk-table">
-	    <thead class="govuk-table__head">
-		<tr class="govuk-table__row">
-		    {% for header in headers %}
-		    <th class="govuk-table__header">{{ header }}</th>
-		    {% endfor %}
-		</tr>
+		<div class="scrollable-table">
+			<table class="govuk-table">
+				<thead class="govuk-table govuk-!-font-size-16">
+				<tr class="govuk-table__row">
+					{% for header in headers %}
+					<th class="govuk-table__header">{{ header }}</th>
+					{% endfor %}
+				</tr>
 
-		<tbody class="govuk-table__body">
-		    {% if data %}
-		    {% for row in data %}
-		    <tr class="govuk-table__row">
-			{% for column in row %}
-			<td class="govuk-table__cell">
-			    {{ column }}
-			</td>
-			{% endfor %}
-		    </tr>
-		    {% endfor %}
-		    {% endif %}
-		</tbody>
-		
-	    </thead>
-	</table>
-	
+				<tbody class="govuk-table__body">
+					{% if data %}
+					{% for row in data %}
+					<tr class="govuk-table__row">
+					{% for column in row %}
+					<td class="govuk-table__cell">
+						{{ column }}
+					</td>
+					{% endfor %}
+					</tr>
+					{% endfor %}
+					{% endif %}
+				</tbody>
+
+				</thead>
+			</table>
+    	</div>
     </div>
 </div>
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,35 +1,51 @@
-
 .text-top {
     vertical-align: text-top;
 }
-
 .float-right {
     float: right;
 }
-
 .pagination {
     float: right;
 }
-
 .pagination li {
     display: inline;
     padding-left: 4px;
 }
-
 .log-sql pre {
     margin: 2px 0px;
 }
-
 .log-sql div {
     max-width: 250px;
     overflow: auto;
     white-space: nowrap;
     padding-right: 10px;
 }
-
 .log-user {
     max-width: 200px;
     overflow: auto;
     white-space: nowrap;
+}
+.scrollable-table {
+  width: 100%;
+  overflow-x: auto;
+  max-height: 560px;
+}
+.scrollable-table table thead th {
+  padding: 15px;
+  background-color: #dee0e2;
+  border-bottom: 0;
+  border-right: 2px solid #fff;
+  font-weight: normal;
+  min-width: 120px;
+  position: relative;
+  vertical-align: middle;
+}
+.scrollable-table table tbody td {
+  padding: 15px;
+  vertical-align: top;
+  border: none;
+}
+.scrollable-table table tbody tr:nth-child(even) td {
+  background-color: #f8f8f8;
 }
 


### PR DESCRIPTION
When a query result table is too wide, a scroll bar is added at the bottom instead of overflowing outside the screen.

![image](https://user-images.githubusercontent.com/5279350/88549772-a092f700-d018-11ea-83c4-da3811bbc9b2.png)
