### PR TITLE
Show username only in multiuser deployments

### DIFF
--- a/core/templates/explorer/query_list.html
+++ b/core/templates/explorer/query_list.html
@@ -72,7 +72,7 @@
             <a href="{% url 'download_query' object.id %}">Download</a>
           </td>
           <td class="govuk-table__cell">{{ object.created_at|date:"SHORT_DATE_FORMAT" }}
-            {% if object.created_by_user %}
+            {% if object.created_by_user and MULTIUSER_DEPLOYMENT %}
             by {{ object.created_by_user }}
             {% endif %}
           </td>

--- a/data_explorer/context_processors.py
+++ b/data_explorer/context_processors.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+
+
+def expose_multiuser_setting(request):
+    return {
+        "MULTIUSER_DEPLOYMENT": settings.MULTIUSER_DEPLOYMENT
+    }

--- a/data_explorer/settings.py
+++ b/data_explorer/settings.py
@@ -117,6 +117,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'data_explorer.context_processors.expose_multiuser_setting',
             ],
         },
     },
@@ -138,6 +139,7 @@ def sort_database_config(database_list):
 
 VCAP_SERVICES = env.json('VCAP_SERVICES', {})
 if VCAP_SERVICES:
+    MULTIUSER_DEPLOYMENT = False
     VCAP_DATABASES = sort_database_config(VCAP_SERVICES['postgres'])
 
     DEFAULT_DATABASE_URL = VCAP_DATABASES[env('POSTGRES_DB')]
@@ -148,6 +150,7 @@ if VCAP_SERVICES:
         'datasets': dj_database_url.parse(DATASETS_DATABASE_URL),
     }
 else:
+    MULTIUSER_DEPLOYMENT = True
     POSTGRES_DB = env.str('POSTGRES_DB')
     POSTGRES_USER = env.str('POSTGRES_USER')
     POSTGRES_PASSWORD = env.str('POSTGRES_PASSWORD')


### PR DESCRIPTION
We plan to deploy the data explorer in two ways:

1) On PaaS as a multi-user tool
2) Via Data Workspace as a single-user tool

In the multi-user case it will be useful to know which user has created
which query, so we'll show the email address of the user in that case.

Ticket: https://trello.com/c/MViADShv/415-display-users-name-instead-of-uuid-in-the-playground-table