### PR TITLE
Pass the selected connection when submitting the playground page

### DIFF
--- a/core/templates/explorer/play.html
+++ b/core/templates/explorer/play.html
@@ -27,7 +27,7 @@
 			<label class="govuk-label" for="id_connection">
 			    Connection
 			</label>
-			<select class="govuk-select" id="id_connection">
+			<select class="govuk-select" id="id_connection" name="connection">
                             {% for value, label in form.connections %}
                             <option value="{{ value|lower }}"{% if form.connection.value == value %} selected{% endif %}>
 				{{ label }}


### PR DESCRIPTION
This was causing the same connection to be used regardless of what the user had chosen