### PR TITLE
Don't `npm install` when deploying to PaaS

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,5 @@
+.envrc
+.env
+.git
+node_modules
+_static

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,9 @@ job_defaults: &job_defaults
 
     - run:
         name: Compile assets
-        command: ./scripts/compile_assets.sh
+        command: |
+          npm install
+          ./scripts/compile_assets.sh
 
     - run:
         name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ COPY . /app
 
 FROM dev AS integrated
 
+RUN npm install
 RUN scripts/compile_assets.sh
 CMD /app/scripts/start.sh

--- a/scripts/compile_assets.sh
+++ b/scripts/compile_assets.sh
@@ -2,6 +2,5 @@
 
 source ./scripts/functions.sh
 
-run "npm install"
 run "npm run-script build"
 run "node -v"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -32,6 +32,7 @@ if [ -z "${COMPILE_ASSETS}" ];
 then
     :
 else
+    run "npm install"
     run "./scripts/compile_assets.sh"
 fi
 run "./scripts/compile_sass.sh"


### PR DESCRIPTION
PaaS will automatically install the dependencies we need during the
staging process of the app when we deploy to PaaS. If we `npm install`
ourselves, it can sometimes be so slow that our app doesn't respond to
the healthcheck in time and so never becomes healthy.

--

When deploying to PaaS, it runs the startup command set in `Procfile`, currently `bash scripts/start_cf.sh`. This runs the `run "./scripts/compile_assets.sh"` script, which does `npm install`. This patch moves `npm install` out to its own step run by the Dockerfile (for DW deployments) and by the `start.sh` script (for local/other deploys).