### PR TITLE
Add pipeline for releasing data-explorer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,58 @@
+pipeline {
+  agent none
+
+  parameters {
+    string(name: 'GIT_COMMIT', defaultValue: 'master', description: 'Commit SHA or origin branch to deploy')
+  }
+
+  stages {
+    stage('release: dev') {
+      steps {
+        ci_pipeline("dev", params.GIT_COMMIT)
+      }
+    }
+
+
+    stage('release: staging') {
+      when {
+          expression {
+              milestone label: "release-staging"
+              input message: 'Deploy to staging?'
+              return true
+          }
+          beforeAgent true
+      }
+
+      steps {
+        ci_pipeline("staging", params.GIT_COMMIT)
+      }
+    }
+
+
+    stage('release: prod') {
+      when {
+          expression {
+              milestone label: "release-prod"
+              input message: 'Deploy to prod?'
+              return true
+          }
+          beforeAgent true
+      }
+
+      steps {
+        ci_pipeline("prod", params.GIT_COMMIT)
+      }
+    }
+  }
+}
+
+void ci_pipeline(env, version) {
+  lock("data-explorer-ci-pipeline-${env}") {
+    build job: "ci-pipeline", parameters: [
+        string(name: "Team", value: "data-workspace-apps"),
+        string(name: "Project", value: "data-explorer"),
+        string(name: "Environment", value: env),
+        string(name: "Version", value: version)
+    ]
+  }
+}


### PR DESCRIPTION
Outstanding question: Is there version control/IAC for the polling pipeline? I made `data-explorer` and `data-explorer-master-scm-poll` projects (duplicated from `data-workspace-` and `data-workspace-master-scm-poll` respectively) via Jenkins UI - not sure if these are just saved by backing up Jenkins or if they're actually created from code/config in some other repo somewhere.