### PR TITLE
Allow save+run after downloading

### DIFF
--- a/static/js/query.js
+++ b/static/js/query.js
@@ -6,6 +6,14 @@ if (createButton) {
 	});
 }
 
+document.getElementById("save_button").addEventListener("click", function(e){
+    document.getElementById("editor").setAttribute("action", "")
+});
+
+document.getElementById("save_only").addEventListener("click", function(e){
+    document.getElementById("editor").setAttribute("action", "")
+});
+
 document.getElementById("download_csv").addEventListener("click", function(e){
     document.getElementById("editor").setAttribute("action", "../download?format=csv")
 });


### PR DESCRIPTION
The "download" buttons mutate the form action permanently, which means
that subsequent clicks on "save/save and run" then just trigger the file
to download again.

This patch removes any action from the form, which makes it post back to
the current URL and allows save/save+run to complete again.