### PR TITLE
fix: allow refreshing after downloading

### DIFF
--- a/core/templates/explorer/play.html
+++ b/core/templates/explorer/play.html
@@ -74,7 +74,7 @@
 
             <div class="govuk-form-group">
             
-            <button class="govuk-button" data-module="govuk-button">
+            <button class="govuk-button" data-module="govuk-button" id="refresh_button">
                 Refresh
             </button>
             <button class="govuk-button govuk-button--secondary" data-module="govuk-button" id="create_button">

--- a/core/templates/explorer/query.html
+++ b/core/templates/explorer/query.html
@@ -128,7 +128,7 @@
                             Save only
                         </button>
                     {% else %}
-                        <button class="govuk-button" data-module="govuk-button">
+                        <button class="govuk-button" data-module="govuk-button" id="refresh_button">
                             Refresh
                         </button>
                     {% endif %}

--- a/static/js/query.js
+++ b/static/js/query.js
@@ -1,4 +1,10 @@
 // Buttons
+var refreshButton = document.getElementById("refresh_button");
+if (refreshButton) {
+	refreshButton.addEventListener("click", function(e){
+		document.getElementById("editor").setAttribute("action", "");
+	});
+}
 var createButton = document.getElementById("create_button");
 if (createButton) {
 	createButton.addEventListener("click", function(e){


### PR DESCRIPTION
The query download buttons alter the form action which then would be
used by the refresh button, meaning the refresh button would end up
downloading the file again.

This patch resets the form action when pressing the refresh button so
that it always just runs the query again.