### PR TITLE
fix: don't explore the default connection

### DIFF
--- a/data_explorer/settings.py
+++ b/data_explorer/settings.py
@@ -176,7 +176,7 @@ else:
         'datasets': DATASETS_DB_CONFIG
     }
 
-EXPLORER_CONNECTIONS = {'default': 'default', 'datasets': 'datasets'}
+EXPLORER_CONNECTIONS = {'datasets': 'datasets'}
 EXPLORER_DEFAULT_CONNECTION = 'datasets'
 
 EXPLORER_SCHEMA_EXCLUDE_TABLE_PREFIXES = ('auth_', 'contenttypes_', 'sessions_', 'admin_', 'data_explorer_', 'django', 'dynamic_models')


### PR DESCRIPTION
Configure the 'default' database as a hidden connection so that, as an
effect of only having one connection left for users to choose, the
connection selector field is hidden.

Depends on https://github.com/uktrade/django-sql-explorer/pull/24