### PR TITLE
fix: update footer

### DIFF
--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -116,31 +116,64 @@
         </div>
 
         <footer class="govuk-footer " role="contentinfo">
-            <div class="govuk-width-container ">
-                <div class="govuk-footer__meta">
-                    <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-                        <h2 class="govuk-visually-hidden">Support links</h2>
-                        <ul class="govuk-footer__inline-list">
-                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="">Cookies</a></li>
-                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="">Privacy, terms and conditions</a></li>
-                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="https://www.great.gov.uk/contact/triage/exporting-to-uk/">Contact</a></li>
-                        </ul>
-                        <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-                            <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
-                        </svg>
-
-                        <span class="govuk-footer__licence-description">
-                            All content is available under the
-                            <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-                        </span>
-                    </div>
-                    <div class="govuk-footer__meta-item">
-                         <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
-                    </div>
-                </div>
+          <div class="govuk-width-container ">
+            <div class="govuk-footer__navigation">
+              <div class="govuk-footer__section">
+                <h2 class="govuk-footer__heading govuk-heading-m">Services and information</h2>
+                <ul class="govuk-footer__list govuk-footer__list--columns-2">
+                  <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="{% url 'explorer_index' %}">
+                      Home
+                    </a>
+                  </li>
+                  <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="{% url 'explorer_playground' %}">
+                      Playground
+                    </a>
+                  </li>
+                  <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="{% url 'query_create' %}">
+                      New Query
+                    </a>
+                  </li>
+                  <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="{% url 'explorer_logs' %}">
+                      Logs
+                    </a>
+                  </li>
+                </ul>
+              </div>
             </div>
+            <hr class="govuk-footer__section-break">
+            <div class="govuk-footer__meta">
+              <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                <h2 class="govuk-visually-hidden">Support links</h2>
+                <ul class="govuk-footer__inline-list">
+                  <li class="govuk-footer__inline-list-item">
+                    <a target="_blank" class="govuk-footer__link" href="https://data-services-help.trade.gov.uk/data-workspace/how-articles/data-workspace-basics/data-workspace-accessibility-statement/">
+                      Accessibility statement
+                    </a>
+                  </li>
+                  <li class="govuk-footer__inline-list-item">
+                    <a target="_blank" class="govuk-footer__link" href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/data-workspace-privacy-policy">
+                      Privacy Policy
+                    </a>
+                  </li>
+                </ul>
+                <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+                  <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+                </svg>
+                <span class="govuk-footer__licence-description">
+                  All content is available under the
+                  <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+                </span>
+              </div>
+              <div class="govuk-footer__meta-item">
+                <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+              </div>
+            </div>
+          </div>
         </footer>
-
         {% block javascript %}
             {% block footer_additions %} {% endblock footer_additions %}
             <script src="{% static 'data_explorer/js/all.js' %}"></script>
@@ -149,6 +182,6 @@
 
         {% load render_bundle from webpack_loader %}
         {% render_bundle 'index' %}
-	    
+
     </body>
 </html>


### PR DESCRIPTION
The current Data Explorer footer links do not go to the correct pages and the design is inconsistent with the rest of Data Workspace

![image](https://user-images.githubusercontent.com/5279350/91048734-fc4ea100-e613-11ea-975d-04c8af692c63.png)
