### PR TITLE
fix: display query execution time

### DIFF
--- a/explorer/templates/explorer/preview_pane.html
+++ b/explorer/templates/explorer/preview_pane.html
@@ -1,3 +1,5 @@
+{% load explorer_tags %}
+
 {% if headers %}
 
 <div class="govuk-grid-row">
@@ -6,7 +8,7 @@
 			Preview
 		</p>
 		<p class="govuk-body">
-			Execution time: {{ duration|floatformat:2 }} ms
+			Execution time: {{ duration|format_duration }}
 		</p>
 		<p class="govuk-body">
 			{% if rows > total_rows %}

--- a/explorer/templatetags/explorer_tags.py
+++ b/explorer/templatetags/explorer_tags.py
@@ -22,3 +22,28 @@ def export_buttons(query=None):
 @register.filter
 def get_item(dictionary, key):
     return dictionary.get(key)
+
+
+@register.filter
+def format_duration(milli_seconds):
+    q, r = divmod(milli_seconds, 1000)
+    millis = round(r, 2)
+    seconds = int(q % 60)
+    minutes = int((q // 60) % 60)
+    hours = int(q // 3600)
+
+    hour_unit = f'hour{"s" if hours != 1 else ""}'
+    minute_unit = f'minute{"s" if minutes != 1 else ""}'
+    second_unit = f'second{"s" if seconds != 1 else ""}'
+    millis_unit = f'millisecond{"s" if millis != 1 else ""}'
+
+    if hours:
+        return (
+            f'{hours} {hour_unit} {minutes} {minute_unit} '
+            f'{seconds} {second_unit} {millis} {millis_unit}'
+        )
+    elif minutes:
+        return f'{minutes} {minute_unit} {seconds} {second_unit} {millis} {millis_unit}'
+    elif seconds:
+        return f'{seconds} {second_unit} {millis} {millis_unit}'
+    return f'{millis} {millis_unit}'

--- a/explorer/tests/test_tags.py
+++ b/explorer/tests/test_tags.py
@@ -1,0 +1,9 @@
+from explorer.templatetags.explorer_tags import format_duration
+
+
+def test_format_duration():
+
+    assert format_duration(36061001.3456) == '10 hours 1 minute 1 second 1.35 milliseconds'
+    assert format_duration(1) == '1 millisecond'
+    assert format_duration(3600000) == '1 hour 0 minutes 0 seconds 0 milliseconds'
+    assert format_duration(1000.2) == '1 second 0.2 milliseconds'


### PR DESCRIPTION
When the user runs a query, the execution time is shown in hours/minutes/seconds/milliseconds format insteas of ms (i.e. 'Execution time: 2987.59 ms' becomes 'Execution time: 2 seconds 987.59 milliseconds')