### PR TITLE
feature: scheduled schema build

### DIFF
--- a/explorer/celery.py
+++ b/explorer/celery.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+from datetime import timedelta
 
 from celery import Celery
+from django.conf import settings
 
-# set the default Django settings module for the 'celery' program.
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'explorer.settings.base')
 
 app = Celery('explorer')
@@ -13,3 +15,16 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()
+
+app.conf.beat_schedule = {}
+
+for alias in settings.EXPLORER_CONNECTIONS:
+    app.conf.beat_schedule.update(
+        {
+            f"trigger-build-schema-{alias}": {
+                "task": "explorer.tasks.build_schema_cache_async",
+                "schedule": timedelta(minutes=8),
+                "args": (alias,),
+            }
+        }
+    )

--- a/explorer/settings/base.py
+++ b/explorer/settings/base.py
@@ -308,6 +308,7 @@ if not MULTIUSER_DEPLOYMENT:
         'default': {
             'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
             'LOCATION': 'unique-snowflake',
+            'TIMEOUT': None,  # never expire
         }
     }
 
@@ -323,9 +324,10 @@ else:
     # Cache
     CACHES = {
         'default': {
-            "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": env.str('REDIS_URL', ''),
-            "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': env.str('REDIS_URL', ''),
+            'OPTIONS': {'CLIENT_CLASS': 'django_redis.client.DefaultClient'},
+            'TIMEOUT': 600,  # 10 min
         }
     }
 

--- a/scripts/start_celery.sh
+++ b/scripts/start_celery.sh
@@ -9,4 +9,4 @@ else
     export REDIS_URL=$(echo $VCAP_SERVICES | jq -r '.redis[0].credentials.uri')
 fi
 
-run "celery -A explorer worker"
+run "celery -A explorer worker --beat"


### PR DESCRIPTION
In a multiuser deployment, the schema building is triggered when the user clicks on show schema.
When there are many tables this can take a while. We change the triggering to a scheduled task to populate
the cache every 8 minutes and the cache will expire every 10 minutes so the schema is quite up to date and
is always availble for quick retrieval from the cache.

In data workspace we assume the schema doesn't change during a user session as the user permissions cannot change. So the cache is set on the start of the session and does not expire.