### PR TITLE
fix: append slash to download URLs

### DIFF
--- a/explorer/static/js/query.js
+++ b/explorer/static/js/query.js
@@ -27,15 +27,15 @@ if (save_only !== null) {
 }
 
 document.getElementById("download_csv").addEventListener("click", function(e){
-    document.getElementById("editor").setAttribute("action", "../download?format=csv")
+    document.getElementById("editor").setAttribute("action", "../download/?format=csv")
 });
 
 document.getElementById("download_excel").addEventListener("click", function(e){
-    document.getElementById("editor").setAttribute("action", "../download?format=excel")
+    document.getElementById("editor").setAttribute("action", "../download/?format=excel")
 });
 
 document.getElementById("download_json").addEventListener("click", function(e){
-    document.getElementById("editor").setAttribute("action", "../download?format=json")
+    document.getElementById("editor").setAttribute("action", "../download/?format=json")
 });
 
 document.getElementById("show_schema_button")


### PR DESCRIPTION
The download buttons were broken because they were posting to URLs without slashes, and we have the Django setting APPEND_SLASHES enabled, which emits a redirect if the URL doesn't end with a slash. The POST data can't be preserved if this happens, so Django throws an exception.

I would like to refactor this JS away in some upcoming updates, but this fix immediately patches the issue.