### PR TITLE
fix: initialise GOV.UK components after DOM loaded

### DIFF
--- a/explorer/templates/explorer/base.html
+++ b/explorer/templates/explorer/base.html
@@ -167,7 +167,12 @@
         {% block javascript %}
             {% block footer_additions %} {% endblock footer_additions %}
             <script src="{% static 'js/all.js' %}"></script>
-            <script>window.GOVUKFrontend.initAll()</script>
+            <script>
+              document.addEventListener('DOMContentLoaded', function () {
+                window.GOVUKFrontend.initAll();
+              });
+            </script>
+          }
         {% endblock %}
 
         {% load render_bundle from webpack_loader %}


### PR DESCRIPTION
The database schema accordion tends to return a lot of rows in
production and sometimes we would end up initialising the GOV.UK Design
System accordion before they had all been loaded into the DOM, meaning
that some tables wouldn't be interactable. By waiting for the DOM
content to be loaded we can make sure all the accordion headers are
initialised properly.

<img width="1307" alt="Screen Shot 2020-09-09 at 13 31 00" src="https://user-images.githubusercontent.com/2920760/92598436-b6930900-f2a0-11ea-9cb2-61b12c2dc7c5.png">
