### PR TITLE
fix: prevent 500 when saving invalid SQL

### DIFF
--- a/explorer/views.py
+++ b/explorer/views.py
@@ -245,6 +245,7 @@ class CreateQueryView(CreateView):
                 )
                 if vm['form'].errors:
                     self.object.delete()
+                    return render(request, self.template_name, vm)
 
                 return HttpResponseRedirect(
                     reverse_lazy('query_detail', kwargs={'query_id': self.object.id})


### PR DESCRIPTION
When there are sql query errors, we need to render the form page again rather
than letting it fall through to the original response, which would raise
a 500 as we've deleted the query object it tries to use.